### PR TITLE
Add Firebase-backed calendar storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # bensonverleih
+
+Simple rental site with a calendar backed by Firebase Firestore.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bensonverleih",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node -e \"console.log('no tests')\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Admin - Benson Verleih</title>
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js"></script>
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+    import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-analytics.js";
+    import { getFirestore, collection, addDoc, getDocs } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyAPbmjJRWdLVKO676Rv_WCLKioWuQwDzTo",
+      authDomain: "bensonverleih.firebaseapp.com",
+      projectId: "bensonverleih",
+      storageBucket: "bensonverleih.firebasestorage.app",
+      messagingSenderId: "778618205850",
+      appId: "1:778618205850:web:4a9dd9b60b2fa8a1e9d123",
+      measurementId: "G-T2CPLMWRP7"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    getAnalytics(app);
+    window.db = getFirestore(app);
+  </script>
+</head>
+<body>
+  <h1>Verfügbarkeit eintragen</h1>
+  <div id="calendar"></div>
+  <form id="addForm">
+    <label>Titel: <input name="title" required></label><br>
+    <label>Startdatum: <input type="date" name="start" required></label><br>
+    <label>Enddatum: <input type="date" name="end" required></label><br>
+    <button type="submit">Speichern</button>
+  </form>
+  <script type="module">
+    async function loadEvents() {
+      const snapshot = await getDocs(collection(window.db, 'events'));
+      return snapshot.docs.map(doc => doc.data());
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+      const calendarEl = document.getElementById('calendar');
+      const calendar = new FullCalendar.Calendar(calendarEl, {
+        initialView: 'dayGridMonth',
+        events: async (info, success) => {
+          const events = await loadEvents();
+          success(events);
+        }
+      });
+      calendar.render();
+
+      document.getElementById('addForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const form = e.target;
+        const data = {
+          title: form.title.value,
+          start: form.start.value,
+          end: form.end.value
+        };
+        await addDoc(collection(window.db, 'events'), data);
+        calendar.refetchEvents();
+        form.reset();
+      });
+    });
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <title>Benson Verleih</title>
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js"></script>
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+    import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-analytics.js";
+    import { getFirestore, collection, addDoc, getDocs } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyAPbmjJRWdLVKO676Rv_WCLKioWuQwDzTo",
+      authDomain: "bensonverleih.firebaseapp.com",
+      projectId: "bensonverleih",
+      storageBucket: "bensonverleih.firebasestorage.app",
+      messagingSenderId: "778618205850",
+      appId: "1:778618205850:web:4a9dd9b60b2fa8a1e9d123",
+      measurementId: "G-T2CPLMWRP7"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    getAnalytics(app);
+    window.db = getFirestore(app);
+  </script>
+</head>
+<body>
+  <h1>Benson Verleih Kalender</h1>
+  <div id="calendar"></div>
+  <h2>Anfrage stellen</h2>
+  <form id="requestForm">
+    <label>Titel: <input name="title" required></label><br>
+    <label>Startdatum: <input type="date" name="start" required></label><br>
+    <label>Enddatum: <input type="date" name="end" required></label><br>
+    <button type="submit">Anfragen</button>
+  </form>
+  <script type="module">
+    async function loadEvents() {
+      const snapshot = await getDocs(collection(window.db, 'events'));
+      return snapshot.docs.map(doc => doc.data());
+    }
+
+    document.addEventListener('DOMContentLoaded', async function() {
+      const calendarEl = document.getElementById('calendar');
+      const calendar = new FullCalendar.Calendar(calendarEl, {
+        initialView: 'dayGridMonth',
+        events: async (info, success) => {
+          const events = await loadEvents();
+          success(events);
+        }
+      });
+      calendar.render();
+
+      document.getElementById('requestForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const form = e.target;
+        const data = {
+          title: form.title.value,
+          start: form.start.value,
+          end: form.end.value
+        };
+        await addDoc(collection(window.db, 'events'), data);
+        calendar.refetchEvents();
+        form.reset();
+      });
+    });
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,31 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const publicDir = path.join(__dirname, 'public');
+
+function send(res, status, data, type) {
+  res.writeHead(status, {'Content-Type': type});
+  res.end(data);
+}
+
+function serveStatic(req, res) {
+  const filePath = req.url === '/' ? '/index.html' : req.url;
+  const fullPath = path.join(publicDir, filePath);
+  fs.readFile(fullPath, (err, data) => {
+    if (err) {
+      send(res, 404, 'Not Found', 'text/plain');
+    } else {
+      const ext = path.extname(fullPath).toLowerCase();
+      const type = ext === '.html' ? 'text/html' : 'text/plain';
+      send(res, 200, data, type);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  serveStatic(req, res);
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => console.log(`Server running on port ${port}`));


### PR DESCRIPTION
## Summary
- integrate Firebase initialization and Firestore event storage in public and admin pages
- remove file-based events API so server only serves static files
- document Firebase calendar backend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab1b9200b88327aad7f8fdc87f7eb7