### PR TITLE
Add product image preview button and lightbox to catalog cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1096,13 +1096,25 @@
         
             if (item.img) {
                 return `
-                    <div class="w-full h-48 bg-[#f5f1ea] flex items-center justify-center overflow-hidden">
+                    <div class="relative w-full h-48 bg-[#f5f1ea] rounded-t-2xl flex items-center justify-center overflow-hidden">
                         <img
                             src="${item.img}"
                             alt="${alt}"
-                            class="max-w-full max-h-full object-contain object-center p-3"
+                            class="max-w-full max-h-full object-contain object-center p-3 rounded-none"
                             onerror="this.parentElement.replaceWith(Object.assign(document.createElement('div'),{className:'w-full h-48 img-fallback',innerHTML:'<span>${alt}</span>'}))"
                         >
+                        <button
+                            type="button"
+                            class="absolute bottom-2 right-2 inline-flex items-center justify-center w-9 h-9 rounded-full bg-black/70 text-white hover:bg-black/80 focus:outline-none focus:ring-2 focus:ring-white/70"
+                            aria-label="Bild vergrößern: ${alt}"
+                            data-preview-img="${item.img}"
+                            data-preview-alt="${alt}"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                <circle cx="11" cy="11" r="7"></circle>
+                                <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                            </svg>
+                        </button>
                     </div>
                 `;
             }
@@ -1138,6 +1150,46 @@
         renderCatalog();
         document.getElementById('catalogSearch')?.addEventListener('input', renderCatalog);
         document.getElementById('catalogFilter')?.addEventListener('change', renderCatalog);
+
+        // === Produktbild-Lightbox ===
+        (function setupPreviewLightbox() {
+            const modal = document.getElementById('imagePreviewModal');
+            const modalImg = document.getElementById('imagePreviewImg');
+            const modalClose = document.getElementById('imagePreviewClose');
+            const modalPanel = document.getElementById('imagePreviewPanel');
+            if (!modal || !modalImg || !modalClose || !modalPanel) return;
+
+            function openPreview(src, alt) {
+                if (!src) return;
+                modalImg.src = src;
+                modalImg.alt = alt || 'Produktbild';
+                modal.classList.remove('hidden');
+                document.body.classList.add('overflow-hidden');
+                modalClose.focus();
+            }
+
+            function closePreview() {
+                modal.classList.add('hidden');
+                modalImg.src = '';
+                modalImg.alt = '';
+                document.body.classList.remove('overflow-hidden');
+            }
+
+            document.addEventListener('click', (e) => {
+                const btn = e.target.closest('[data-preview-img]');
+                if (!btn) return;
+                e.preventDefault();
+                openPreview(btn.getAttribute('data-preview-img'), btn.getAttribute('data-preview-alt'));
+            });
+
+            modalClose.addEventListener('click', closePreview);
+            modal.addEventListener('click', (e) => {
+                if (!modalPanel.contains(e.target)) closePreview();
+            });
+            document.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape' && !modal.classList.contains('hidden')) closePreview();
+            });
+        })();
 
         // === Warenkorb & Berechnung ===
         const cart = (window.cart ||= new Map());
@@ -1560,6 +1612,15 @@
         })();
     </script>
 
+
+    <div id="imagePreviewModal" class="hidden fixed inset-0 z-[100] bg-black/75 p-4 sm:p-8">
+        <div id="imagePreviewPanel" class="relative mx-auto flex h-full w-full max-w-5xl items-center justify-center">
+            <button id="imagePreviewClose" type="button" class="absolute right-1 top-1 z-10 inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/90 text-slate-900 hover:bg-white focus:outline-none focus:ring-2 focus:ring-white" aria-label="Vorschau schließen">
+                ✕
+            </button>
+            <img id="imagePreviewImg" src="" alt="" class="max-h-full max-w-full object-contain rounded-xl bg-[#f5f1ea] p-2" />
+        </div>
+    </div>
 
     <script src="bv-base.js"></script>
 </body>


### PR DESCRIPTION
### Motivation
- Enable users to inspect product images in a larger view and improve the visual presentation of catalog cards.

### Description
- Add an overlay preview button to the card image markup in `cardImageHTML` that exposes `data-preview-img` and `data-preview-alt` and includes an accessible label and SVG icon.
- Tweak image/card classes to use rounded corners on the card top and adjust image sizing classes for consistent layout.
- Introduce an IIFE `setupPreviewLightbox()` that wires a modal lightbox with `openPreview`/`closePreview`, click-outside and `Escape` handling, and delegates preview button clicks to open the modal.
- Append modal markup (`#imagePreviewModal`, `#imagePreviewPanel`, `#imagePreviewImg`, `#imagePreviewClose`) into `index.html` for the lightbox UI.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79ce7d7f0832785e89718c77bd0d0)